### PR TITLE
Fix some date display bugs and improve scroll positions

### DIFF
--- a/src/components/DateDisplay.js
+++ b/src/components/DateDisplay.js
@@ -30,7 +30,8 @@ const useStyles = makeStyles((theme) => ({
     display: 'block',
     transition: 'all linear .3s',
     position: 'relative',
-    left: '0px'
+    left: '0px',
+    cursor: 'pointer'
   },
   displayDateButtonActive: {
     color: '#333333',
@@ -67,9 +68,7 @@ function DateDisplay({viewDate, onDateSelection}) {
               key={i}
               onClick={() => onDateSelection(dateString)}
               className={
-                isActiveDateOption(i) ?
-                  clsx(classes.displayDateButton, classes.displayDateButtonActive) :
-                  classes.displayDateButton
+                clsx(classes.displayDateButton, isActiveDateOption(i) && classes.displayDateButtonActive)
               }>
               { display }
             </button>

--- a/src/components/NewsItem.js
+++ b/src/components/NewsItem.js
@@ -76,6 +76,9 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
+// to get correct date to display
+const publishedDate = (newsObject) => new Date(newsObject.attributes.published_on + " 12:00");
+
 const NewsItem = (props) => {
   const classes = useStyles();
 
@@ -96,7 +99,7 @@ const NewsItem = (props) => {
   })
 
   // format date string
-  const dateString = generateDateString(props.newsObject.attributes.published_on, true)
+  const dateString = generateDateString(publishedDate(props.newsObject), true)
 
   return (
     <Card className={classes.newsCard}>

--- a/src/components/NewsWrapper.js
+++ b/src/components/NewsWrapper.js
@@ -2,7 +2,7 @@ import React, {useState, useEffect} from 'react';
 import debounce from 'lodash.debounce';
 import {setDateFromScroll} from "../actions/actions";
 import {connect} from "react-redux";
-import {sampleIncluded, sampleNewsObjects} from "../sampleData/singleObject";
+import {sampleIncluded, sampleNewsObjects} from "../sampleData/apiData_20200329";
 import {triggeringAgents} from "../reducers/reducer";
 
 // styling
@@ -52,6 +52,9 @@ const useStyles = makeStyles((theme) => ({
     top: '0',
   }
 }));
+
+// to get proper dates
+const publishedDate = (newsObject) => new Date(newsObject.attributes.published_on + " 12:00");
 
 function NewsWrapper(props) {
 
@@ -127,12 +130,12 @@ function NewsWrapper(props) {
 
   const getPositionOfFirstNewsItemPublishedBefore = (date) => {
     const ixNewsObjectToScrollTo = newsObjects.findIndex(object =>
-      new Date(object.attributes.published_on) <= date
+      publishedDate(object) <= date
     );
 
     const newsItemElements = [...document.getElementsByName(NEWS_ITEM_NAME)];
     const elementToScrollTo = newsItemElements[ixNewsObjectToScrollTo];
-    return elementToScrollTo.offsetTop;
+    return elementToScrollTo.offsetTop + elementToScrollTo.offsetParent.offsetTop;
   };
 
   const getPublishDateOfFirstVisibleNewsItem = () => {
@@ -140,12 +143,12 @@ function NewsWrapper(props) {
       const newsItemElements = [...document.getElementsByName(NEWS_ITEM_NAME)];
 
       const ixFirstVisibleNewsItem = newsItemElements.findIndex(element =>
-        element.offsetTop >= document.documentElement.scrollTop
+        element.offsetTop + element.offsetParent.offsetTop >= document.documentElement.scrollTop
       );
 
       return ixFirstVisibleNewsItem > -1
-        ? new Date(newsObjects[ixFirstVisibleNewsItem].attributes.published_on)
-        : new Date(newsObjects[0].attributes.published_on);
+        ? publishedDate(newsObjects[ixFirstVisibleNewsItem])
+        : publishedDate(newsObjects[0]);
     }
 
     return null


### PR DESCRIPTION
**NOTE**: I branched off the issue-5 branch. It would be nice to merge this PR before that one.

### Summary
Noticed the news item dates were all one day earlier than the API results, due to javascript, timezones, etc. Required a fix to all places where we create date from .published_on field.

Also made a correction to how we determine and set scroll position.