### PR TITLE
Parse and Display all dates as UTC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8848,6 +8848,14 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
+    "moment-timezone": {
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
+      "integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "axios": "^0.19.2",
     "lodash.debounce": "^4.0.8",
     "moment": "^2.24.0",
+    "moment-timezone": "^0.5.28",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-inlinesvg": "^1.2.0",

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -3,24 +3,24 @@ export const SET_DATE_FROM_SCROLL = "SET_DATE_FROM_SCROLL";
 export const SET_DATE_FROM_CALENDAR = "SET_DATE_FROM_CALENDAR";
 
 
-export function setDateFromDisplay(viewDate) {
+export function setDateFromDisplay(viewDateString) {
     return {
         type: SET_DATE_FROM_DISPLAY,
-        viewDate: viewDate
+        viewDateString: viewDateString
     };
 }
 
-export function setDateFromScroll(viewDate) {
+export function setDateFromScroll(viewDateString) {
     return {
         type: SET_DATE_FROM_SCROLL,
-        viewDate: viewDate
+        viewDateString: viewDateString
     };
 }
 
-export function setDateFromCalendar(viewDate) {
+export function setDateFromCalendar(viewDateString) {
     return {
         type: SET_DATE_FROM_CALENDAR,
-        viewDate: viewDate
+        viewDateString: viewDateString
     };
 }
 

--- a/src/components/DateDisplay.js
+++ b/src/components/DateDisplay.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {connect} from "react-redux";
 import {setDateFromDisplay} from "../actions/actions";
-import {generateDateDisplayOptions, today} from "../utils/dateDisplayOptions";
+import dateDisplayOptions from "../utils/dateDisplayOptions";
 
 // styling
 import clsx from 'clsx';
@@ -51,7 +51,7 @@ function DateDisplay({viewDate, onDateSelection}) {
 
   // TODO: Determine date range based on results from the API
   const earliestDate = new Date(2020, 0, 1);
-  const dateOptions = generateDateDisplayOptions(today(), earliestDate);
+  const dateOptions = dateDisplayOptions(earliestDate);
 
   const isActiveDateOption = (i) => {
     return dateOptions[i+1]
@@ -81,7 +81,7 @@ function DateDisplay({viewDate, onDateSelection}) {
 
 function mapStateToProps(state) {
   return {
-    viewDate: new Date(state.viewDate)
+    viewDate: new Date(state.viewDateString)
   }
 }
 

--- a/src/components/NewsItem.js
+++ b/src/components/NewsItem.js
@@ -15,6 +15,7 @@ import link from '../icons/link.svg'
 
 // utils
 import generateDateString from '../utils/generateDateString'
+import {publishedDate} from "../utils/dateHelpers";
 
 const useStyles = makeStyles((theme) => ({
   newsCard: {
@@ -77,8 +78,6 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-// to get correct date to display
-const publishedDate = (newsObject) => new Date(newsObject.attributes.published_on);
 
 const NewsItem = (props) => {
   const classes = useStyles();

--- a/src/components/NewsWrapper.js
+++ b/src/components/NewsWrapper.js
@@ -2,7 +2,6 @@ import React, {useState, useEffect} from 'react';
 import debounce from 'lodash.debounce';
 import {setDateFromScroll} from "../actions/actions";
 import {connect} from "react-redux";
-import {sampleIncluded, sampleNewsObjects} from "../sampleData/apiData_20200329";
 import {triggeringAgents} from "../reducers/reducer";
 
 // styling
@@ -63,11 +62,11 @@ function NewsWrapper(props) {
 
   // config state
   const classes = useStyles();
-  const [newsObjects, setNewsObjects] = useState(sampleNewsObjects);
-  const [included, setIncluded] = useState(sampleIncluded);
+  const [newsObjects, setNewsObjects] = useState([]);
+  const [included, setIncluded] = useState([]);
 
   const [numberPagesLoaded, setNumberPagesLoaded] = useState(0);
-  const [morePagesAvailable, setMorePagesAvailable] = useState(false);
+  const [morePagesAvailable, setMorePagesAvailable] = useState(true);
   const [morePagesNeeded, setMorePagesNeeded] = useState(false);
   const [isFetching, setIsFetching] = useState(false);
   const NEWS_ITEM_NAME = "newsItem";

--- a/src/components/NewsWrapper.js
+++ b/src/components/NewsWrapper.js
@@ -18,6 +18,7 @@ import NewsItem from './NewsItem'
 // utils
 import axios from 'axios';
 import axiosHeader from '../utils/axiosHeader'
+import {publishedDate} from "../utils/dateHelpers";
 
 const useStyles = makeStyles((theme) => ({
   cardsWrapper: {
@@ -57,24 +58,22 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
-// to get proper dates
-const publishedDate = (newsObject) => new Date(newsObject.attributes.published_on);
 
 function NewsWrapper(props) {
 
   // config state
   const classes = useStyles();
-  const [newsObjects, setNewsObjects] = useState([]);
-  const [included, setIncluded] = useState([]);
+  const [newsObjects, setNewsObjects] = useState(sampleNewsObjects);
+  const [included, setIncluded] = useState(sampleIncluded);
 
   const [numberPagesLoaded, setNumberPagesLoaded] = useState(0);
-  const [morePagesAvailable, setMorePagesAvailable] = useState(true);
+  const [morePagesAvailable, setMorePagesAvailable] = useState(false);
   const [morePagesNeeded, setMorePagesNeeded] = useState(false);
   const [isFetching, setIsFetching] = useState(false);
   const NEWS_ITEM_NAME = "newsItem";
 
   useEffect(() => {
-    const viewDate = new Date(props.viewDate);
+    const viewDate = new Date(props.viewDateString);
 
     const earliestFetchedPublishDate = getEarliestFetchedPublishDate();
     if (viewDate < earliestFetchedPublishDate){
@@ -93,7 +92,7 @@ function NewsWrapper(props) {
         window.scrollTo(0, scrollPosition)
       }
     }
-  }, [props.viewDate, newsObjects]);
+  }, [props.viewDateString, newsObjects]);
 
 
   const loadEvents = () => {
@@ -128,7 +127,7 @@ function NewsWrapper(props) {
 
   const getEarliestFetchedPublishDate = () => {
     return newsObjects.length
-      ? new Date(newsObjects[newsObjects.length-1].attributes.published_on)
+      ? publishedDate(newsObjects[newsObjects.length-1])
       : new Date();
   };
 
@@ -165,7 +164,7 @@ function NewsWrapper(props) {
         props.onScrollDateChange(publishedDate.toISOString());
       }
     } else {
-      props.onScrollDateChange(props.viewDate);
+      props.onScrollDateChange(props.viewDateString);
     }
   };
 
@@ -205,7 +204,8 @@ function NewsWrapper(props) {
 
 function mapStateToProps(state) {
   return {
-    viewDate: state.viewDate,
+    viewDate: new Date(state.viewDateString),
+    viewDateString: state.viewDateString,
     triggeringAgent: state.triggeringAgent
   }
 }

--- a/src/components/NewsWrapper.js
+++ b/src/components/NewsWrapper.js
@@ -203,7 +203,6 @@ function NewsWrapper(props) {
 
 function mapStateToProps(state) {
   return {
-    viewDate: new Date(state.viewDateString),
     viewDateString: state.viewDateString,
     triggeringAgent: state.triggeringAgent
   }

--- a/src/components/sidebar/CalendarPicker.js
+++ b/src/components/sidebar/CalendarPicker.js
@@ -5,6 +5,7 @@ import {DatePicker, MuiPickersUtilsProvider} from "@material-ui/pickers";
 import MomentUtils from "@date-io/moment";
 import {connect} from "react-redux";
 import {setDateFromCalendar} from "../../actions/actions";
+import moment from 'moment-timezone';
 
 const useStyles = makeStyles(() => ({
   calendarIconWrapper: {
@@ -26,8 +27,12 @@ const useStyles = makeStyles(() => ({
   }
 }));
 
+
+moment.tz.setDefault("GMT");
+
+
 function CalendarPicker (props) {
-  const viewDate = new Date(props.viewDate);
+  const viewDate = new Date(props.viewDateString);
   const classes = useStyles();
   const [isOpen, setIsOpen] = useState(false);
 
@@ -38,7 +43,7 @@ function CalendarPicker (props) {
         alt="Choose Date"
         className={classes.calendarIcon}
         onClick={() => {setIsOpen(true)}}/>
-      <MuiPickersUtilsProvider utils={MomentUtils}>
+      <MuiPickersUtilsProvider utils={MomentUtils} moment={moment}>
         <DatePicker
           autoOk
           open={isOpen}
@@ -48,7 +53,6 @@ function CalendarPicker (props) {
           value={viewDate}
           disableToolbar={false}
           onChange={(date) => {
-            console.log('hey!');
             props.onDateSelection(date.toISOString())
           }}
           style={{display: "none"}}
@@ -61,7 +65,7 @@ function CalendarPicker (props) {
 
 function mapStateToProps(state) {
   return {
-    viewDate: state.viewDate
+    viewDateString: state.viewDateString
   }
 }
 

--- a/src/components/sidebar/Sidebar.js
+++ b/src/components/sidebar/Sidebar.js
@@ -128,12 +128,12 @@ function Sidebar(props) {
   const [totalRecovered, updateTotalRecovered] = useState('-')
   const [totalDeaths, updateTotalDeaths] = useState('-')
 
-  let dateString = generateDateString(props.viewDate, false)
+  let dateString = generateDateString(props.viewDateString, false)
 
   useEffect(() => {
-    dateString = generateDateString(props.viewDate, false)
-    getCaseData(props.viewDate)
-  }, [props.viewDate])
+    dateString = generateDateString(props.viewDateString, false)
+    getCaseData(props.viewDateString)
+  }, [props.viewDateString])
 
   useEffect(() => {
     calculateStatTotals()
@@ -247,7 +247,7 @@ function Sidebar(props) {
 
 function mapStateToProps(state) {
   return {
-    viewDate: new Date(state.viewDate)
+    viewDateString: state.viewDateString
   }
 }
 

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -1,5 +1,4 @@
 import {SET_DATE_FROM_CALENDAR, SET_DATE_FROM_DISPLAY, SET_DATE_FROM_SCROLL} from "../actions/actions";
-import {today} from "../utils/dateDisplayOptions";
 
 export const triggeringAgents = {
     DATE_DISPLAY: 'DATE_DISPLAY',
@@ -8,24 +7,24 @@ export const triggeringAgents = {
 };
 
 const initialState = {
-    viewDate: today().toISOString()
+    viewDateString: new Date().toISOString()
 };
 
 export default function rootReducer(state = initialState, action) {
     switch (action.type) {
         case SET_DATE_FROM_DISPLAY:
             return Object.assign({}, state, {
-                viewDate: action.viewDate,
+                viewDateString: action.viewDateString,
                 triggeringAgent: triggeringAgents.DATE_DISPLAY
             });
         case SET_DATE_FROM_SCROLL:
             return Object.assign({}, state, {
-                viewDate: action.viewDate,
+                viewDateString: action.viewDateString,
                 triggeringAgent: triggeringAgents.NEWS_LIST
             });
         case SET_DATE_FROM_CALENDAR:
             return Object.assign({}, state, {
-                viewDate: action.viewDate,
+                viewDateString: action.viewDateString,
                 triggeringAgent: triggeringAgents.CALENDAR_PICKER
             });
         default:

--- a/src/utils/dateDisplayOptions.js
+++ b/src/utils/dateDisplayOptions.js
@@ -1,3 +1,5 @@
+import * as moment from "moment";
+
 const monthDisplayNames = [
     "JAN",
     "FEB",
@@ -13,16 +15,11 @@ const monthDisplayNames = [
     "DEC"
 ];
 
-export function today() {
-    let dt = new Date();
-    return new Date(dt.getFullYear(), dt.getMonth(), dt.getDate())
-}
-
 function allMonthsLeadingUpTo(currentMonth, currentYear) {
     return [...Array(currentMonth)].map((_, ix) => {
         return {
             display: monthDisplayNames[currentMonth - ix - 1],
-            dateString: new Date(currentYear, currentMonth - ix, 1).toISOString()
+            dateString: moment.utc([currentYear, currentMonth - ix - 1]).endOf('month').toISOString()
         }
     });
 }
@@ -31,7 +28,7 @@ function allYearsBetween(earliestYear, currentYear) {
     return [...Array(currentYear - earliestYear)].map((_, ix) => {
         return {
             display: (currentYear - ix - 1).toString(),
-            dateString: new Date(currentYear - ix, 0, 1).toISOString()
+            dateString: moment.utc([currentYear - ix - 1]).endOf('year').toISOString()
         }
     });
 }
@@ -40,17 +37,17 @@ function allMonthsBetween(earliestMonth, currentMonth, currentYear) {
     return [...Array(currentMonth - earliestMonth)].map((_, ix) => {
         return {
             display: monthDisplayNames[currentMonth - ix - 1],
-            dateString: new Date(currentYear, currentMonth - ix, 1).toISOString()
+            dateString: moment.utc([currentYear, currentMonth - ix - 1]).endOf('month').toISOString()
         }
     });
 }
 
 export function generateDateDisplayOptions(currentDate, earliestDate) {
-    let currentYear = currentDate.getFullYear();
-    let currentMonth = currentDate.getMonth();
+    let currentYear = currentDate.getUTCFullYear();
+    let currentMonth = currentDate.getUTCMonth();
 
-    let earliestYear = earliestDate.getFullYear();
-    let earliestMonth = earliestDate.getMonth();
+    let earliestYear = earliestDate.getUTCFullYear();
+    let earliestMonth = earliestDate.getUTCMonth();
 
     let earlierMonths = [];
     let earlierYears = [];
@@ -70,4 +67,9 @@ export function generateDateDisplayOptions(currentDate, earliestDate) {
         ...earlierMonths,
         ...earlierYears,
     ];
+}
+
+export default function dateDisplayOptions(earliestDate) {
+    const today = moment().utc().endOf('day').toDate();
+    return generateDateDisplayOptions(today, earliestDate);
 }

--- a/src/utils/dateDisplayOptions.spec.js
+++ b/src/utils/dateDisplayOptions.spec.js
@@ -7,27 +7,27 @@ describe("generateDateDisplayOptions", () => {
        const actual = generateDateDisplayOptions(fakeToday, new Date());
 
        expect(actual[0].display).toEqual("TODAY");
-       expect(actual[0].date).toMatch(/^2020-05-27/);
+       expect(actual[0].dateString).toMatch(/^2020-05-27/);
     });
 
     it("returns previous month and beginning of current month's date as second element", () => {
         const actual = generateDateDisplayOptions(fakeToday, new Date(2020, 0, 1));
 
         expect(actual[1].display).toEqual("APR");
-        expect(actual[1].date).toMatch(/^2020-05-01/);
+        expect(actual[1].dateString).toMatch(/^2020-04-30T23:59/);
     });
 
     it("returns all months of the year leading up to current month when earliest date is in previous year", () => {
         const actual = generateDateDisplayOptions(fakeToday, new Date(2019, 11, 11));
 
         expect(actual[2].display).toEqual("MAR");
-        expect(actual[2].date).toMatch(/^2020-04-01/);
+        expect(actual[2].dateString).toMatch(/^2020-03-31T23:59/);
 
         expect(actual[3].display).toEqual("FEB");
-        expect(actual[3].date).toMatch(/^2020-03-01/);
+        expect(actual[3].dateString).toMatch(/^2020-02-29T23:59/);
 
         expect(actual[4].display).toEqual("JAN");
-        expect(actual[4].date).toMatch(/^2020-02-01/);
+        expect(actual[4].dateString).toMatch(/^2020-01-31T23:59/);
     });
 
     it("returns months of the year between earliest month and current month when earliest date is in current year", () => {
@@ -36,13 +36,13 @@ describe("generateDateDisplayOptions", () => {
         expect(actual).toHaveLength(3);
 
         expect(actual[0].display).toEqual("TODAY");
-        expect(actual[0].date).toMatch(/^2020-05-27/);
+        expect(actual[0].dateString).toMatch(/^2020-05-27/);
 
         expect(actual[1].display).toEqual("APR");
-        expect(actual[1].date).toMatch(/^2020-05-01/);
+        expect(actual[1].dateString).toMatch(/^2020-04-30T23:59/);
 
         expect(actual[2].display).toEqual("MAR");
-        expect(actual[2].date).toMatch(/^2020-04-01/);
+        expect(actual[2].dateString).toMatch(/^2020-03-31T23:59/);
     });
 
     it("returns previous year and beginning of current year as the last element when earliest date is in previous year", () => {
@@ -50,7 +50,7 @@ describe("generateDateDisplayOptions", () => {
 
         const n = actual.length;
         expect(actual[n-1].display).toEqual("2019");
-        expect(actual[n-1].date).toMatch(/^2020-01-01/);
+        expect(actual[n-1].dateString).toMatch(/^2019-12-31T23:59/);
     });
 
     it("returns no previous years when earliest date is in current year", () => {
@@ -65,12 +65,12 @@ describe("generateDateDisplayOptions", () => {
 
         const n = actual.length;
         expect(actual[n-1].display).toEqual("2017");
-        expect(actual[n-1].date).toMatch(/^2018-01-01/);
+        expect(actual[n-1].dateString).toMatch(/^2017-12-31T23:59/);
 
         expect(actual[n-2].display).toEqual("2018");
-        expect(actual[n-2].date).toMatch(/^2019-01-01/);
+        expect(actual[n-2].dateString).toMatch(/^2018-12-31T23:59/);
 
         expect(actual[n-3].display).toEqual("2019");
-        expect(actual[n-3].date).toMatch(/^2020-01-01/);
+        expect(actual[n-3].dateString).toMatch(/^2019-12-31T23:59/);
     });
 });

--- a/src/utils/dateHelpers.js
+++ b/src/utils/dateHelpers.js
@@ -1,0 +1,5 @@
+import * as moment from "moment";
+
+export function publishedDate(newsObject) {
+  return moment.utc(newsObject.attributes.published_on, "YYYY-MM-DD").toDate()
+}

--- a/src/utils/generateAsOfDate.js
+++ b/src/utils/generateAsOfDate.js
@@ -2,14 +2,14 @@
 export default function (dateToGen) {
   const publishedDate = new Date(dateToGen)
 
-  const dateYear = publishedDate.getFullYear()
+  const dateYear = publishedDate.getUTCFullYear()
 
-  let dateMonth = publishedDate.getMonth() + 1
+  let dateMonth = publishedDate.getUTCMonth() + 1
   if (dateMonth.toString().length === 1) {
     dateMonth = `0${dateMonth }`
   }
 
-  let dateDate = publishedDate.getDate()
+  let dateDate = publishedDate.getUTCDate()
   if (dateDate.toString().length === 1) {
     dateDate = `0${dateDate }`
   }

--- a/src/utils/generateDateString.js
+++ b/src/utils/generateDateString.js
@@ -1,9 +1,9 @@
 // returns string formatted like "JAN 01, 2020" or "JAN 01" based on displayYearBool for use with UI components
 export default function (dateToGen, displayYearBool) {
   const publishedDate = new Date(dateToGen)
-  const monthIndex = publishedDate.getMonth()
-  const dateDate = publishedDate.getDate()
-  const dateYear = publishedDate.getFullYear()
+  const monthIndex = publishedDate.getUTCMonth()
+  const dateDate = publishedDate.getUTCDate()
+  const dateYear = publishedDate.getUTCFullYear()
   const months = [
     'JAN',
     'FEB',


### PR DESCRIPTION
I decided to express all dates as UTC in hopes of avoiding any timezone quirks.

- Explicitly parse `published_on` date as UTC
- Use UTC values when displaying date strings
- Rename date value in redux to be explicitly a string
- Adjust date ranges for DateDisplay component (to use `endOf` month)
- Force DatePicker to be on UTC time