### PR TITLE
TV - set number of pages loaded and news objects list at same time

### DIFF
--- a/src/components/newsfeed/NewsWrapper.js
+++ b/src/components/newsfeed/NewsWrapper.js
@@ -105,6 +105,7 @@ function NewsWrapper(props) {
         .then(
           (res) => {
             if (res.data.data) {
+              setNumberPagesLoaded(numberPagesLoaded+1);
               setNewsObjects(numberPagesLoaded ? newsObjects.concat(res.data.data) : res.data.data);
             }
             if (res.data.included) {
@@ -113,7 +114,6 @@ function NewsWrapper(props) {
             if (res.data.meta?.pagination?.pages) {
               setMorePagesAvailable(res.data.meta.pagination.pages > (numberPagesLoaded + 1))
             }
-            setNumberPagesLoaded(numberPagesLoaded+1);
           }
         )
         .catch(


### PR DESCRIPTION
Closes #19 

A change to the `newsObjects` was triggering another `loadEvents()` before it got around to updating to the number of pages loaded.