### PR TITLE
Create chart of infections in sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1409,6 +1409,101 @@
         "glob-to-regexp": "^0.3.0"
       }
     },
+    "@nivo/annotations": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.61.0.tgz",
+      "integrity": "sha512-i2JKYeMEPC+zwgN/p+hVRWUJ4aee+kE8BfMzCLt1/a+rsfT+v2v5kj12zx072teoaQt53lOi1GdV2lEYA6HJpg==",
+      "requires": {
+        "@nivo/colors": "0.61.0",
+        "@nivo/core": "0.61.0",
+        "lodash": "^4.17.11",
+        "react-motion": "^0.5.2"
+      }
+    },
+    "@nivo/axes": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.61.0.tgz",
+      "integrity": "sha512-U0rHIYNnwt03dFFBz0aosfd5nFIRVD1Wff5DwVeM7PouBZM3AsLVWeLlUWLWOmg+BHftqhbOGTOoZN2SjU7bwA==",
+      "requires": {
+        "@nivo/core": "0.61.0",
+        "d3-format": "^1.3.2",
+        "d3-time": "^1.0.11",
+        "d3-time-format": "^2.1.3",
+        "lodash": "^4.17.11",
+        "react-motion": "^0.5.2"
+      }
+    },
+    "@nivo/bar": {
+      "version": "0.61.1",
+      "resolved": "https://registry.npmjs.org/@nivo/bar/-/bar-0.61.1.tgz",
+      "integrity": "sha512-MYdjeFt6HqEyIBFwbVHKPjpw8+DPirAZwJDZi7dPXT0F7WcwJOnRITlRHhmQEGq5u71h26UN+M0z/ZQkB54mvw==",
+      "requires": {
+        "@nivo/annotations": "0.61.0",
+        "@nivo/axes": "0.61.0",
+        "@nivo/colors": "0.61.0",
+        "@nivo/core": "0.61.0",
+        "@nivo/legends": "0.61.1",
+        "@nivo/tooltip": "0.61.0",
+        "d3-scale": "^3.0.0",
+        "d3-shape": "^1.2.2",
+        "lodash": "^4.17.11",
+        "react-motion": "^0.5.2",
+        "recompose": "^0.30.0"
+      }
+    },
+    "@nivo/colors": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.61.0.tgz",
+      "integrity": "sha512-yeb5YsQDoN7D5DbBIhHTnVn0bX+4ObNVGyJAepSn64zNPiskO3/o1FnQw70aIkN4O7BDXb/vVPrftq6wSwQtvQ==",
+      "requires": {
+        "d3-color": "^1.2.3",
+        "d3-scale": "^3.0.0",
+        "d3-scale-chromatic": "^1.3.3",
+        "lodash.get": "^4.4.2",
+        "lodash.isplainobject": "^4.0.6",
+        "react-motion": "^0.5.2"
+      }
+    },
+    "@nivo/core": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.61.0.tgz",
+      "integrity": "sha512-7DGsTW12vfUvMIr9jl28KZaJMJqMMhEJi1lW1R2TPMTg+qSG01v6tqMtcEwUp4bdAdr3n57ytLWSgqKWXkwjvw==",
+      "requires": {
+        "@nivo/tooltip": "0.61.0",
+        "d3-color": "^1.2.3",
+        "d3-format": "^1.3.2",
+        "d3-hierarchy": "^1.1.8",
+        "d3-interpolate": "^1.3.2",
+        "d3-scale": "^3.0.0",
+        "d3-scale-chromatic": "^1.3.3",
+        "d3-shape": "^1.3.5",
+        "d3-time-format": "^2.1.3",
+        "lodash": "^4.17.11",
+        "react-measure": "^2.2.4",
+        "react-motion": "^0.5.2",
+        "recompose": "^0.30.0"
+      }
+    },
+    "@nivo/legends": {
+      "version": "0.61.1",
+      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.61.1.tgz",
+      "integrity": "sha512-bKVXffFwTKGySZRUf6sdVzWUb5jjGffuvRczs0giQCu8OUgeJIi0IOOyYhHtww+rTVGIKAi0xPGQTQnF4kpufA==",
+      "requires": {
+        "@nivo/core": "0.61.0",
+        "lodash": "^4.17.11",
+        "recompose": "^0.30.0"
+      }
+    },
+    "@nivo/tooltip": {
+      "version": "0.61.0",
+      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.61.0.tgz",
+      "integrity": "sha512-CqEJ4v1jSikZ3fmuSJVb1UYF8fuCo/c7JFB+LsNH9X01IERSufO3tSNBTzJ3JugCminQpbo6/R7oBhNwZFqSxw==",
+      "requires": {
+        "@nivo/core": "0.61.0",
+        "react-measure": "^2.2.4",
+        "react-motion": "^0.5.2"
+      }
+    },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
@@ -3312,6 +3407,11 @@
         "supports-color": "^5.3.0"
       }
     },
+    "change-emitter": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
+      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
+    },
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -4160,6 +4260,81 @@
         "type": "^1.0.1"
       }
     },
+    "d3-array": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.4.0.tgz",
+      "integrity": "sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw=="
+    },
+    "d3-color": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.0.tgz",
+      "integrity": "sha512-TzNPeJy2+iEepfiL92LAAB7fvnp/dV2YwANPVHdDWmYMm23qIJBYww3qT8I8C1wXrmrg4UWs7BKc2tKIgyjzHg=="
+    },
+    "d3-format": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.4.tgz",
+      "integrity": "sha512-TWks25e7t8/cqctxCmxpUuzZN11QxIA7YrMbram94zMQ0PXjE4LVIMe/f6a4+xxL8HQ3OsAFULOINQi1pE62Aw=="
+    },
+    "d3-hierarchy": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
+      "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ=="
+    },
+    "d3-interpolate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
+      "requires": {
+        "d3-color": "1"
+      }
+    },
+    "d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "d3-scale": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.1.tgz",
+      "integrity": "sha512-huz5byJO/6MPpz6Q8d4lg7GgSpTjIZW/l+1MQkzKfu2u8P6hjaXaStOpmyrD6ymKoW87d2QVFCKvSjLwjzx/rA==",
+      "requires": {
+        "d3-array": "1.2.0 - 2",
+        "d3-format": "1",
+        "d3-interpolate": "^1.2.0",
+        "d3-time": "1",
+        "d3-time-format": "2"
+      }
+    },
+    "d3-scale-chromatic": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz",
+      "integrity": "sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==",
+      "requires": {
+        "d3-color": "1",
+        "d3-interpolate": "1"
+      }
+    },
+    "d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "requires": {
+        "d3-path": "1"
+      }
+    },
+    "d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "d3-time-format": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.3.tgz",
+      "integrity": "sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==",
+      "requires": {
+        "d3-time": "1"
+      }
+    },
     "damerau-levenshtein": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz",
@@ -4634,6 +4809,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -5628,6 +5811,35 @@
         "bser": "2.1.1"
       }
     },
+    "fbjs": {
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "requires": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        },
+        "promise": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+          "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+          "requires": {
+            "asap": "~2.0.3"
+          }
+        }
+      }
+    },
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -5992,6 +6204,11 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "get-node-dimensions": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-node-dimensions/-/get-node-dimensions-1.2.1.tgz",
+      "integrity": "sha512-2MSPMu7S1iOTL+BOa6K1S62hB2zUAYNF/lV0gSVlOaacd087lc6nR1H1r0e3B1CerTo+RceOmi1iJW+vp21xcQ=="
     },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.2",
@@ -6971,6 +7188,15 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -7281,8 +7507,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7300,13 +7525,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7319,18 +7542,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7433,8 +7653,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7444,7 +7663,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7457,20 +7675,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7487,7 +7702,6 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -7543,8 +7757,7 @@
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -7569,8 +7782,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7580,7 +7792,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7649,8 +7860,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7680,7 +7890,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7698,7 +7907,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7737,13 +7945,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         }
@@ -8440,6 +8646,16 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8976,6 +9192,15 @@
       "requires": {
         "lower-case": "^2.0.1",
         "tslib": "^1.10.0"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-forge": {
@@ -11144,6 +11369,39 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-measure": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-measure/-/react-measure-2.3.0.tgz",
+      "integrity": "sha512-dwAvmiOeblj5Dvpnk8Jm7Q8B4THF/f1l1HtKVi0XDecsG6LXwGvzV5R1H32kq3TW6RW64OAf5aoQxpIgLa4z8A==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "get-node-dimensions": "^1.2.1",
+        "prop-types": "^15.6.2",
+        "resize-observer-polyfill": "^1.5.0"
+      }
+    },
+    "react-motion": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/react-motion/-/react-motion-0.5.2.tgz",
+      "integrity": "sha512-9q3YAvHoUiWlP3cK0v+w1N5Z23HXMj4IF4YuvjvWegWqNPfLXsOBE/V7UvQGpXxHFKRQQcNcVQE31g9SB/6qgQ==",
+      "requires": {
+        "performance-now": "^0.2.0",
+        "prop-types": "^15.5.8",
+        "raf": "^3.1.0"
+      },
+      "dependencies": {
+        "performance-now": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+        }
+      }
+    },
     "react-redux": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.0.tgz",
@@ -11270,6 +11528,26 @@
       "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
       "requires": {
         "util.promisify": "^1.0.0"
+      }
+    },
+    "recompose": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
+      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "change-emitter": "^0.1.2",
+        "fbjs": "^0.8.1",
+        "hoist-non-react-statics": "^2.3.1",
+        "react-lifecycles-compat": "^3.0.2",
+        "symbol-observable": "^1.0.4"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
       }
     },
     "recursive-readdir": {
@@ -11517,6 +11795,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.15.0",
@@ -13134,6 +13417,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "ua-parser-js": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -13472,8 +13760,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -13491,13 +13778,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -13510,18 +13795,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -13624,8 +13906,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -13635,7 +13916,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -13648,20 +13928,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -13678,7 +13955,6 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -13734,8 +14010,7 @@
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -13760,8 +14035,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -13771,7 +14045,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -13840,8 +14113,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -13871,7 +14143,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -13889,7 +14160,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -13928,13 +14198,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -14248,8 +14516,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -14267,13 +14534,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -14286,18 +14551,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -14400,8 +14662,7 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -14411,7 +14672,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -14424,20 +14684,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -14454,7 +14711,6 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -14510,8 +14766,7 @@
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -14536,8 +14791,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -14547,7 +14801,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -14616,8 +14869,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -14647,7 +14899,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -14665,7 +14916,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -14704,13 +14954,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@date-io/moment": "^1.3.13",
     "@material-ui/core": "^4.9.7",
     "@material-ui/pickers": "^3.2.10",
+    "@nivo/bar": "^0.61.1",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",

--- a/src/components/sidebar/InfectionCurve.js
+++ b/src/components/sidebar/InfectionCurve.js
@@ -8,6 +8,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import axios from "axios";
 import axiosHeader from "../../utils/axiosHeader";
 import generateDateString from "../../utils/generateDateString";
+import * as moment from "moment";
 
 const useStyles = makeStyles((theme) => ({
   chartAreaWrapper: {
@@ -22,18 +23,26 @@ const useStyles = makeStyles((theme) => ({
   },
   chartTitle: {
     fontSize: '12px',
-    color: '#000',
+    color: '#757575',
     fontWeight: '700'
+  },
+  tooltipLabel: {
+    fontSize: '10px',
+    margin: '0'
   }
 }));
+
+// primary color: hsl(258, 100%, 50%)
+const infected_text_color = "hsla(243, 100%, 60%)";
+const infected_bar_color = "hsla(233, 100%, 83%)";
+const deaths_bar_color = "red";
+
 
 function InfectionCurve() {
   const classes = useStyles();
   const [chartData, setChartData] = useState([]);
 
-
   useEffect(() => {
-      console.log("useMemo");
       getCaseData()
     }, []);
 
@@ -44,14 +53,16 @@ function InfectionCurve() {
       .then((res) => {
         if (res.status === 200) {
           if (res.data.data) {
-            const newChartData = res.data.data.map((dataPoint) => {
-              // use UTC here
-              return {
-                as_of: dataPoint.as_of,
-                total_infected: dataPoint.sum_total,
-                total_deaths: dataPoint.sum_deaths,
-              }
-            });
+            const newChartData = res.data.data
+              .map((dataPoint) => {
+                return {
+                  as_of_string: generateDateString(dataPoint.as_of, false),
+                  day_of_week: moment.utc(dataPoint.as_of).day(),
+                  total_infected: dataPoint.sum_total,
+                  total_deaths: dataPoint.sum_deaths,
+                }
+              })
+              .filter(dataPoint => dataPoint.day_of_week === 6);
 
             setChartData(newChartData);
           }
@@ -62,37 +73,33 @@ function InfectionCurve() {
       })
   };
 
-  const infected_color = "hsla(240, 50%, 80%)";
-  const infected_color_readable = "hsla(240, 50%, 60%)";
-  const deaths_color = "red";
-
   return (
     <div className={classes.chartAreaWrapper}>
-      <h6 className={classes.chartTitle}>INFECTION CURVE</h6>
+      <h6 className={classes.chartTitle}>WEEKLY INFECTION TOTALS</h6>
       <div className={classes.chartWrapper}>
         <ResponsiveBar
           data={chartData}
-          keys={['total_infected', 'total_deaths']}
-          indexBy="as_of"
+          keys={['total_deaths', 'total_infected']}
+          indexBy="as_of_string"
           margin={{ top: 0, right: 0, bottom: 5, left: 40 }}
           padding={0.3}
-          colors={[infected_color, deaths_color]}
+          colors={[deaths_bar_color, infected_bar_color]}
           enableLabel={false}
           tooltip={({data}) => (
             <div>
-              <p style={{fontSize: '10px', margin: '0'}}>
-                TOTALS AS OF {generateDateString(data.as_of, false)}
+              <p className={classes.tooltipLabel}>
+                AS OF {data.as_of_string}
               </p>
-              <p style={{color: infected_color_readable, fontSize: '10px', margin: '0'}}>
-                INFECTED: {data.total_infected}
+              <p style={{color: infected_text_color}} className={classes.tooltipLabel}>
+                {data.total_infected} INFECTED
               </p>
-              <p style={{color: deaths_color, fontSize: '10px', margin: '0'}}>
-                DEATHS: {data.total_deaths}
+              <p style={{color: deaths_bar_color}} className={classes.tooltipLabel}>
+                {data.total_deaths} DEATHS
               </p>
             </div>
           )
           }
-          xFormat="time:%Y-%m-%d"
+          enableGridX={false}
           enableGridY={true}
           gridYValues={4}
           axisTop={null}

--- a/src/components/sidebar/InfectionCurve.js
+++ b/src/components/sidebar/InfectionCurve.js
@@ -1,19 +1,114 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
+import { ResponsiveBar } from '@nivo/bar'
 
 // styling
 import { makeStyles } from '@material-ui/core/styles';
 
+// utils
+import axios from "axios";
+import axiosHeader from "../../utils/axiosHeader";
+import generateDateString from "../../utils/generateDateString";
+
 const useStyles = makeStyles((theme) => ({
-  mapWrapper: {
-    padding: '11px 0px'
+  chartAreaWrapper: {
+    padding: '11px 0px',
+    [theme.breakpoints.down('xs')]: {
+      display: 'none'
+    }
+  },
+  chartWrapper: {
+    height: '15rem',
+    paddingTop: '15px',
+  },
+  chartTitle: {
+    fontSize: '12px',
+    color: '#000',
+    fontWeight: '700'
   }
 }));
 
 function InfectionCurve() {
   const classes = useStyles();
+  const [chartData, setChartData] = useState([]);
+
+
+  useEffect(() => {
+      console.log("useMemo");
+      getCaseData()
+    }, []);
+
+  const getCaseData = () => {
+    const url = `https://ohioready-api.zwink.net/v1/case_summary.agg/?aggregate[Sum]=total&aggregate[Sum]=deaths&aggregate[Sum]=recovered&group_by[as_of]`;
+
+    axios.get(url, axiosHeader)
+      .then((res) => {
+        if (res.status === 200) {
+          if (res.data.data) {
+            const newChartData = res.data.data.map((dataPoint) => {
+              // use UTC here
+              return {
+                as_of: dataPoint.as_of,
+                total_infected: dataPoint.sum_total,
+                total_deaths: dataPoint.sum_deaths,
+              }
+            });
+
+            setChartData(newChartData);
+          }
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+      })
+  };
+
+  const infected_color = "hsla(240, 50%, 80%)";
+  const infected_color_readable = "hsla(240, 50%, 60%)";
+  const deaths_color = "red";
+
   return (
-    <div className={classes.mapWrapper}>
-      chart here
+    <div className={classes.chartAreaWrapper}>
+      <h6 className={classes.chartTitle}>INFECTION CURVE</h6>
+      <div className={classes.chartWrapper}>
+        <ResponsiveBar
+          data={chartData}
+          keys={['total_infected', 'total_deaths']}
+          indexBy="as_of"
+          margin={{ top: 0, right: 0, bottom: 5, left: 40 }}
+          padding={0.3}
+          colors={[infected_color, deaths_color]}
+          enableLabel={false}
+          tooltip={({data}) => (
+            <div>
+              <p style={{fontSize: '10px', margin: '0'}}>
+                TOTALS AS OF {generateDateString(data.as_of, false)}
+              </p>
+              <p style={{color: infected_color_readable, fontSize: '10px', margin: '0'}}>
+                INFECTED: {data.total_infected}
+              </p>
+              <p style={{color: deaths_color, fontSize: '10px', margin: '0'}}>
+                DEATHS: {data.total_deaths}
+              </p>
+            </div>
+          )
+          }
+          xFormat="time:%Y-%m-%d"
+          enableGridY={true}
+          gridYValues={4}
+          axisTop={null}
+          axisRight={null}
+          axisBottom={null}
+          axisLeft={{
+            tickSize: 0,
+            tickPadding: 4,
+            tickRotation: 0,
+            tickValues: 4
+          }}
+          animate={true}
+          motionStiffness={200}
+          motionDamping={30}
+         />
+      </div>
     </div>
   );
 }

--- a/src/components/sidebar/Sidebar.js
+++ b/src/components/sidebar/Sidebar.js
@@ -13,7 +13,7 @@ import Card from '@material-ui/core/Card';
 // components
 import Statistics from './Statistics'
 import OhioMap from './OhioMap'
-// import InfectionCurve from './InfectionCurve' ---- to be used later
+import InfectionCurve from './InfectionCurve'
 import CalendarPicker from "./CalendarPicker";
 import FooterIcons from './FooterIcons'
 
@@ -239,9 +239,8 @@ function Sidebar(props) {
             allCountiesData={allCountiesData}
             ></OhioMap>
 
-          {/* PAUSED FOR NOW - see https://github.com/chekcreative/ohio-ready/issues/7 */}
-          {/* <hr className={classes.sidebarHR}/>
-          <InfectionCurve></InfectionCurve> */}
+          <hr className={clsx(classes.sidebarHR, classes.onlyDesktopSidebarHR)}/>
+          <InfectionCurve></InfectionCurve>
 
           {/* FOOTER ICONS FOR MOBILE */}
           <div className={classes.footerIconMobile}>


### PR DESCRIPTION
Added a chart to the sidebar to display weekly infection totals.  I am using [nivo](https://nivo.rocks/) for this currently.

I am open to feedback on the design

April 4th will be our 3rd Saturday of data, so it will start off looking roughly like this.  
(This screenshot was generated using Thursdays):
<img width="260" alt="Screen Shot 2020-04-03 at 7 04 01 PM" src="https://user-images.githubusercontent.com/19788219/78411534-f82ad400-75dd-11ea-96f8-1545c82c047f.png">
